### PR TITLE
malware-shield: exclude repo's own EICAR fixture from yara scans

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -884,7 +884,26 @@
         clamav = { enable = true; onAccess = false; };
         rootkit.enable = true;
         aide.enable = true;
-        yara.enable = true;
+        yara = {
+          enable = true;
+          # Setting excludePaths here replaces the module's default outright,
+          # so both original entries are repeated below — dropping them would
+          # silently re-enable the .claude/projects false positives the
+          # default was written to prevent.
+          excludePaths = [
+            "/home/*/.claude/projects"
+            "/home/*/.claude/file-history"
+            # This repo's own EICAR pipeline-test fixture and the doc that
+            # demonstrates it (modules/security/yara-rules/eicar.yar,
+            # docs/security-hardening.md) both contain the literal EICAR
+            # test string by design — the same structural false positive as
+            # the two paths above, just from a second source the default
+            # list didn't anticipate: a checkout of this repo living under a
+            # scanned path.
+            "/home/*/Documents/oligarchy2/Oligarchy/modules/security/yara-rules"
+            "/home/*/Documents/oligarchy2/Oligarchy/docs/security-hardening.md"
+          ];
+        };
       };
 
       # sops-nix wiring (modules/secrets.nix). Safe with zero consumers:


### PR DESCRIPTION
## Summary

\`malware-shield-yara.service\` fired a "critical" desktop notification during this session for two files in this repo: \`modules/security/yara-rules/eicar.yar\` and \`docs/security-hardening.md\`. Both are expected, deterministic self-matches, not real detections — investigated live, not assumed.

- \`eicar.yar\` **is** the YARA rule for the industry-standard EICAR antivirus test string, and contains that string twice: once as the pattern being matched, once in a comment demonstrating how to test the pipeline.
- \`docs/security-hardening.md:148-149\` documents that exact same test command, with the same string.

Neither is malware. \`configuration.nix\` sets \`level = "monitor"\` (\`onDetection = "log"\`), so nothing gets quarantined here — this is pure notification noise, not a functional bug — but it's permanent: any yara sweep of \`/home\` (the default \`scanPaths\`) will re-trigger on both files for as long as a checkout of this repo exists under a scanned path, which is exactly where a dev checkout normally lives.

The module already anticipated this general failure mode: \`yara.excludePaths\`' default already excludes \`.claude/projects\`/\`.claude/file-history\`, with a comment explicitly citing "EICAR test markers... causing structural false positives on every scan" as the reason. This PR just extends the same treatment to the second, equally predictable source the default list didn't cover: the repo's own test fixture.

## Change

\`configuration.nix\`: \`custom.malwareShield.yara.excludePaths\` now explicitly lists all four paths (the original two plus the repo's \`modules/security/yara-rules\` and \`docs/security-hardening.md\`) — setting this option replaces the module's default outright, so the original two had to be repeated to avoid silently re-enabling the \`.claude\` false positives while fixing this one.

## Verification

- \`nix eval\` clean for the \`nixos\` host.
- Root-caused by reading the actual triggering rule file and cross-referencing the running \`malware-shield-yara.service\`'s command line (\`systemctl status\`) against \`modules/security/malware-shield.nix\`'s exclude-list design and comments — not guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)