### PR TITLE
oligarchy-forge: add claude/opencode/ollama/codex/aider/cursor agents

### DIFF
--- a/modules/oligarchy-forge/crates/forge-core/src/render.rs
+++ b/modules/oligarchy-forge/crates/forge-core/src/render.rs
@@ -17,6 +17,7 @@ pub fn render_flake(cfg: &ForgeConfig) -> Result<String> {
     ctx.insert("image_name", &cfg.image_name());
     ctx.insert("packages", &cfg.nix_packages().join(" "));
     ctx.insert("agent_wrappers", &cfg.agent_wrappers_nix());
+    ctx.insert("needs_claude_code_nix", &cfg.needs_claude_code_nix());
 
     tera.render("flake.nix", &ctx)
         .context("rendering flake.nix from template")
@@ -68,6 +69,58 @@ mod tests {
         )
         .unwrap();
         let out = render_flake(&cfg).unwrap();
+        assert!(!out.contains("writeShellScriptBin"));
+    }
+
+    #[test]
+    fn claude_agent_pulls_in_claude_code_nix_as_a_flake_input() {
+        let cfg = ForgeConfig::parse(
+            r#"
+            [project]
+            name = "demo"
+            agents = ["claude"]
+            "#,
+        )
+        .unwrap();
+        let out = render_flake(&cfg).unwrap();
+        assert!(out.contains("inputs.claude-code-nix.url = \"github:sadjow/claude-code-nix\";"));
+        assert!(out.contains("outputs = { self, nixpkgs, claude-code-nix }:"));
+        assert!(out.contains("claude-code-nix.packages.${system}.claude-code"));
+    }
+
+    #[test]
+    fn claude_code_nix_input_absent_when_claude_not_selected() {
+        let cfg = ForgeConfig::parse(
+            r#"
+            [project]
+            name = "demo"
+            agents = ["oh-my-pi", "opencode", "ollama"]
+            "#,
+        )
+        .unwrap();
+        let out = render_flake(&cfg).unwrap();
+        assert!(!out.contains("claude-code-nix"));
+        assert!(out.contains("outputs = { self, nixpkgs }:"));
+        // Plain nixpkgs agents land in the packages list, not the wrapper list.
+        assert!(out.contains("opencode"));
+        assert!(out.contains("ollama"));
+    }
+
+    #[test]
+    fn codex_aider_cursor_are_plain_nixpkgs_packages() {
+        let cfg = ForgeConfig::parse(
+            r#"
+            [project]
+            name = "demo"
+            agents = ["codex", "aider", "cursor"]
+            "#,
+        )
+        .unwrap();
+        let out = render_flake(&cfg).unwrap();
+        assert!(out.contains("codex"));
+        assert!(out.contains("aider-chat"));
+        assert!(out.contains("cursor-cli"));
+        assert!(!out.contains("claude-code-nix"));
         assert!(!out.contains("writeShellScriptBin"));
     }
 }

--- a/modules/oligarchy-forge/crates/forge-core/src/schema.rs
+++ b/modules/oligarchy-forge/crates/forge-core/src/schema.rs
@@ -121,10 +121,36 @@ impl Extension {
 #[serde(rename_all = "kebab-case")]
 pub enum Agent {
     OhMyPi,
+    Claude,
+    // Overrides the derived kebab-case "open-code" — the actual tool/binary
+    // is one word, "opencode".
+    #[serde(rename = "opencode")]
+    OpenCode,
+    Ollama,
+    Codex,
+    Aider,
+    Cursor,
 }
 
 impl Agent {
-    pub const ALL: [Agent; 1] = [Agent::OhMyPi];
+    pub const ALL: [Agent; 7] = [
+        Agent::OhMyPi,
+        Agent::Claude,
+        Agent::OpenCode,
+        Agent::Ollama,
+        Agent::Codex,
+        Agent::Aider,
+        Agent::Cursor,
+    ];
+
+    /// True for agents whose CLI comes from a flake input rather than a
+    /// plain nixpkgs attribute or a `wrapper_script()`-built derivation —
+    /// see `Agent::Claude` and `ForgeConfig::needs_claude_code_nix()`. The
+    /// generated flake only declares (and therefore only ever fetches) the
+    /// `claude-code-nix` input when this is true for some selected agent.
+    pub fn needs_flake_input(self) -> bool {
+        matches!(self, Agent::Claude)
+    }
 
     /// nixpkgs attribute names this agent's wrapper needs at runtime, beyond
     /// what `wrapper_script()` already brings in via its own `let` block
@@ -133,12 +159,27 @@ impl Agent {
     pub fn packages(self) -> &'static [&'static str] {
         match self {
             Agent::OhMyPi => &[],
+            // Claude Code isn't in nixpkgs at all (Anthropic ships it as an
+            // npm package only) — sourced from the claude-code-nix flake
+            // input instead, see `wrapper_script()`.
+            Agent::Claude => &[],
+            Agent::OpenCode => &["opencode"],
+            Agent::Ollama => &["ollama"],
+            Agent::Codex => &["codex"],
+            Agent::Aider => &["aider-chat"],
+            Agent::Cursor => &["cursor-cli"],
         }
     }
 
     pub fn label(self) -> &'static str {
         match self {
             Agent::OhMyPi => "oh-my-pi",
+            Agent::Claude => "claude",
+            Agent::OpenCode => "opencode",
+            Agent::Ollama => "ollama",
+            Agent::Codex => "codex",
+            Agent::Aider => "aider",
+            Agent::Cursor => "cursor",
         }
     }
 
@@ -151,6 +192,35 @@ impl Agent {
                  (1.3.3), which fails to parse its bundle. Installed lazily and \
                  version-pinned on first use instead of baked in at image-build time \
                  (nixpkgs has no reproducible-build helper for Bun package installs)."
+            }
+            Agent::Claude => {
+                "Claude Code (`claude`) — Anthropic's agentic coding CLI. Not in \
+                 nixpkgs (npm-only upstream); packaged reproducibly via the \
+                 community github:sadjow/claude-code-nix flake, pulled in as an \
+                 extra flake input only when this agent is selected for a project."
+            }
+            Agent::OpenCode => {
+                "OpenCode (`opencode`) — open-source terminal coding agent, \
+                 multi-provider (works with local Ollama models as well as \
+                 hosted ones). Plain nixpkgs package, no wrapper needed."
+            }
+            Agent::Ollama => {
+                "Ollama (`ollama`) — local model runtime, for troubleshooting \
+                 fully offline or as OpenCode's/a custom agent's backend. Plain \
+                 nixpkgs package; pull a model yourself on first use \
+                 (`ollama pull <model>`) — no model is baked into the image."
+            }
+            Agent::Codex => {
+                "OpenAI Codex CLI (`codex`) — lightweight terminal coding agent. \
+                 Plain nixpkgs package, no wrapper needed."
+            }
+            Agent::Aider => {
+                "Aider (`aider`) — AI pair programming in the terminal, git-aware \
+                 diffs. Plain nixpkgs package (`aider-chat`), no wrapper needed."
+            }
+            Agent::Cursor => {
+                "Cursor CLI (`cursor-agent`) — Cursor's terminal coding agent. \
+                 Plain nixpkgs package (`cursor-cli`), no wrapper needed."
             }
         }
     }
@@ -203,6 +273,19 @@ in pkgs.writeShellScriptBin "omp" ''
   exec "$bin" "$@"
 '')"#
             }
+            // No wrapper needed: claude-code-nix's own package is already a
+            // complete, reproducible derivation for the real `claude`
+            // binary. The generated flake only declares this input at all
+            // when Agent::Claude is selected — see
+            // ForgeConfig::needs_claude_code_nix() and the Tera template.
+            Agent::Claude => "claude-code-nix.packages.${system}.claude-code",
+            // Plain nixpkgs packages — packages() above is sufficient,
+            // nothing to bake in here.
+            Agent::OpenCode => "",
+            Agent::Ollama => "",
+            Agent::Codex => "",
+            Agent::Aider => "",
+            Agent::Cursor => "",
         }
     }
 }
@@ -285,6 +368,14 @@ impl ForgeConfig {
     /// `contents` list (see `Agent::wrapper_script()`).
     pub fn agent_wrappers_nix(&self) -> String {
         self.project.agents.iter().map(|a| a.wrapper_script()).collect::<Vec<_>>().join(" ")
+    }
+
+    /// Whether any selected agent needs a flake input beyond plain nixpkgs
+    /// (currently: Agent::Claude, via claude-code-nix). The generated
+    /// flake's `inputs` only ever grow to include claude-code-nix when this
+    /// is true, so a project that never selects Claude never fetches it.
+    pub fn needs_claude_code_nix(&self) -> bool {
+        self.project.agents.iter().any(|a| a.needs_flake_input())
     }
 
     /// Every pair of currently-selected extensions that provide the same

--- a/modules/oligarchy-forge/crates/forge-core/templates/flake.nix.tera
+++ b/modules/oligarchy-forge/crates/forge-core/templates/flake.nix.tera
@@ -3,11 +3,19 @@
 
   # Pinned to match the parent Oligarchy repo's channel (see CLAUDE.md).
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-
-  outputs = { self, nixpkgs }:
+{% if needs_claude_code_nix %}
+  # Claude Code isn't in nixpkgs (npm-only upstream) — only declared (and
+  # therefore only ever fetched) when the "claude" agent is actually
+  # selected for this project, see Agent::needs_flake_input().
+  inputs.claude-code-nix.url = "github:sadjow/claude-code-nix";
+{% endif %}
+  outputs = { self, nixpkgs{% if needs_claude_code_nix %}, claude-code-nix{% endif %} }:
     let
       system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
+      # Matches the parent Oligarchy flake's own stance (CLAUDE.md: "Unfree +
+      # broken allowed") — needed for real agents in the catalog, e.g. Cursor
+      # CLI (nixpkgs marks cursor-cli unfree; refuses to evaluate otherwise).
+      pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
     in
     {
       packages.${system}.default = pkgs.dockerTools.streamLayeredImage {


### PR DESCRIPTION
## Summary

Extends \`oligarchy-forge\`'s Agent catalog (previously just \`oh-my-pi\`) with six more terminal coding agents, so the sandboxed coding-agent runner can install and expose any of them on \`PATH\` inside a project's sandbox.

- **\`claude\`** — Claude Code isn't in nixpkgs (npm-only upstream). Sourced from the community \`github:sadjow/claude-code-nix\` flake. The generated sandbox flake only declares (and therefore only ever fetches) that extra input when Claude is actually selected for a project (\`Agent::needs_flake_input()\` / \`ForgeConfig::needs_claude_code_nix()\` gate a conditional block in the Tera template) — a project that never picks Claude never pays the extra fetch.
- **\`opencode\`, \`ollama\`, \`codex\`, \`aider\`, \`cursor\`** — all plain nixpkgs packages (\`opencode\`, \`ollama\`, \`codex\`, \`aider-chat\`, \`cursor-cli\` respectively), just \`Agent::packages()\` entries, no custom wrapper needed.

Also fixes \`config.allowUnfree\` on the generated flake's own \`pkgs\` instance, matching the parent Oligarchy flake's own stance (CLAUDE.md: "Unfree + broken allowed") — \`cursor-cli\` is marked unfree in nixpkgs and the generated sandbox would otherwise refuse to evaluate it at all.

## Real bugs this caught by actually building, not just unit-testing

- **The unfree refusal only showed up building a real image** — every `cargo test` passed while `oligarchy-forge build` still failed outright on the first real attempt with Cursor selected.
- **`opencode`'s auto-derived TOML key would have been wrong.** `#[serde(rename_all = "kebab-case")]` turns `OpenCode` into `"open-code"`, but the actual tool/binary is one word, `opencode`. Caught by a test asserting the real command name, fixed with an explicit `#[serde(rename = "opencode")]`.

## Verification

- \`cargo test --workspace\` in \`modules/oligarchy-forge\`: 17 forge-core + 8 forge-tui tests pass, including 3 new tests covering the \`claude-code-nix\` conditional input (present only when selected, absent otherwise) and the plain-nixpkgs agents.
- \`nix eval\` clean across all 4 top-level hosts (nixos, nixos-fw13, nixos-intel, nixos-optimus).
- **End-to-end, not just eval/tests**: ran \`oligarchy-forge build\` with all 7 agents selected in one project, loaded the resulting image into podman, and ran every agent's \`--version\` inside the actual running container:
  - \`claude\` → \`2.1.233 (Claude Code)\`
  - \`codex\` → \`codex-cli 0.92.0\`
  - \`aider\` → \`aider 0.86.1\`
  - \`cursor-agent\` → \`2025.11.06-8fe8a63\`
  - \`opencode\` → \`1.1.14\`
  - \`ollama\` → client \`0.21.1\`
  - \`omp\` → lazy-install path triggered correctly on first run (unchanged, still oh-my-pi's existing behavior)

## Test plan

- [x] \`cargo test --workspace\`
- [x] \`nix eval\` all 4 hosts
- [x] Real container build + every agent's \`--version\` verified inside it
- [ ] Interactive TUI check (agent tree picker) on a real Hyprland session — not done here, existing \`forge-tui\` unit tests cover the tree-toggle logic but not a live render

🤖 Generated with [Claude Code](https://claude.com/claude-code)