### PR TITLE
docs: cover today's merges (theme engine, control center, forge agents, demod-talk, YARA fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,10 @@ This isn’t just a system — it’s a conquest machine engineered to dominate 
 - **Modular Package Management**: Nix declarative control — Steam, Lutris, Snap, NVIDIA optional.
 - **Desktop Arsenal**: Hyprland primary (blazing Wayland), Plasma 6 optional, Cinnamon/X11 fallback.
 - **Streamlined Installation**: Calamares conquers encrypted setup, user creation, and full stack deployment.
-- **Customization Scripts**: Resolution cycling, theme switching, web apps, DCF control, keybinding cheatsheets — all via Wofi or hotkeys.
+- **Customization Scripts**: Resolution cycling, *live* theme switching (8 palettes, re-skins waybar/wofi/hyprlock/GTK/Kvantum/kitty in place — no rebuild), web apps, DCF control, keybinding cheatsheets — all via Wofi or hotkeys.
+- **Unified Command Palette**: `Super+D` opens the control center — flat fuzzy-search across every action, or browse by category (appearance, AI, DSP, DCF, network, security, power, persona, rig, system). Same registry backs the fzf terminal front-end and the phone-bridge passthrough.
 - **Snap Support**: Optional, expands arsenal without breaking reproducibility.
+- **Sandboxed Coding-Agent Runner** (`oligarchy-forge`): declarative `oligarchy-forge.toml` → generated flake → rootless Podman/Docker sandbox. Pick your toolchain (Rust/Python/Node/Go/Faust-JACK) and your agent — Claude Code, OpenCode, Ollama, Codex, Aider, Cursor, or Oh My Pi — and it's on `PATH` inside the box, never on the host.
 - **DCF Compute Fabric**: Real-time multiplayer/edge fabric with community node, identity/billing, tray controller, and hardened containers.
 - **Virtual Camera**: `v4l2loopback` for streaming domination.
 - **Rust Greeting System**: Kitty graphics protocol for displaying brand images directly in terminal, adaptive layout based on terminal size, system info display, and interactive TUI launcher.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,13 +192,30 @@ builds a feature/profile set (`defaultFeatures`, `profiles/`) that gates
 desktop pieces, and a theme/palette system in `home/themes/` (the
 `p` / `activeTheme` shorthand seen throughout).
 
+8 palettes live in `home/themes/default.nix` as the single source of
+truth; `home/apps/theme-variants.nix` renders every palette (not just the
+active one) to `~/.config/oligarchy/themes/<id>/` — a JSON palette dump
+plus each themed app's own pre-rendered config variant (waybar CSS, wofi
+CSS, hyprlock conf, GTK3/4 CSS, a Kvantum theme directory per palette,
+a kitty colors-only conf). `theme-switch.sh` reads only these Nix-rendered
+files (`toggle`/`set <id>`/`gui`/`cli`/`current`/`list`) and actually
+re-skins every consumer live — no rebuild needed — by re-pointing each
+app's Home-Manager-managed symlink at the selected variant, rewriting
+Kvantum's active-theme pointer, and pushing new colors into running kitty
+windows via `kitty @ set-colors` (kitty.nix sets `allow_remote_control` +
+a `{kitty_pid}`-suffixed `listen_on`, since the three pre-spawned
+scratchpad kitty processes would otherwise collide on one static socket
+path). The next `home-manager switch` still resets everything to whatever
+`activeThemeName` declares — this is a live preview/override, not a second
+source of truth.
+
 Layout split:
 
 ```
 home/
 ├── apps/      — KDE/Qt/GTK theming
 ├── hyprland/  — Hyprland config
-├── waybar/    — Waybar widgets (DCF/Ollama/DSP/caffeine indicators)
+├── waybar/    — Waybar widgets (DCF/Ollama/DSP/caffeine/repo-update indicators)
 ├── x11/       — X11 fallbacks
 ├── terminal/ — Kitty/foot/shell integrations
 ├── shell/     — zsh/fish aliases, completions, prompts
@@ -208,6 +225,49 @@ home/
 Many `home/apps/*` modules take a `theme`/palette argument rather than
 reading global config, so the same module builds differently against
 different palettes.
+
+### 7a. Control center (`home/apps/control-center/`)
+
+Plain bash, deployed to `~/.local/bin`, sharing one action registry so the
+two front-ends and the phone-bridge passthrough (`modules/hypr-controller/`)
+never duplicate dispatch logic:
+
+- `oligarchy-ctl` — the registry itself: `status` / `cats` / `items <cat>`
+  / `all-items` (every category's actions flattened into one list, for
+  fuzzy search) / `run <action-id>`. ~50 actions across 10 categories
+  (appearance, ai, dsp, dcf, network, security, power, persona, rig,
+  system). Mutates live state (`hyprctl keyword`, `pw-metadata`,
+  `powerprofilesctl`) and persists build-time choices (persona/kernel/gpu)
+  to `oligarchy-local.nix` — this is the read-write control layer,
+  deliberately separate from the read-only MCP surface.
+- `oligarchy-menu` (wofi, Super+D) / `oligarchy-control` (fzf, terminal) —
+  both support the category→action browse and a flat "🔎 Search all
+  actions…" entry point.
+- `persona-menu` (`oligarchy-ctl run persona-menu`) — one-shot picker
+  showing all 4 personas with the active one checked, switching via the
+  same `apply_persona` logic the flat items use.
+- `dcf-control` — small fzf panel over the `dcf` category's read-only
+  status (`hydramesh-status`/`-logs`) and mutating actions
+  (`hydramesh-restart`/`-pull`); bound directly to `$mod SHIFT, D` when
+  `features.enableDCF`.
+- `ai` category's `forge-agent` entry launches `oligarchy-forge run --
+  $OLIGARCHY_FORGE_AGENT` (default `claude`, a `home.sessionVariables`
+  override) when `oligarchy-forge` is installed — see §10 for the agent
+  catalog that command can select from.
+- `system` category's `repo-check` / `repo-pull` wrap
+  `home/scripts/repo-update-check.sh` and a fast-forward-only `git pull`.
+  That same script backs waybar's `custom/repo-updates` badge
+  (`features.enableDev`-gated): a systemd user timer fetches every 30
+  minutes and notifies once per new remote SHA (never repeats for a commit
+  already surfaced); the badge itself only polls cached refs (no network
+  call) and renders nothing at all when clean — confirmed by screenshotting
+  a live instance with deliberately obnoxious CSS on the module, not just
+  assumed from an empty string. Resolves whichever branch is actually
+  checked out and its real upstream (`@{u}`, falling back to
+  `origin/main`/`origin/master`) rather than assuming a branch named
+  `main` — the real deployed checkout at `/etc/nixos` is on `master` with
+  no upstream configured at all, which a hardcoded comparison would have
+  silently done nothing for.
 
 ## 8. Security — the iron curtain
 
@@ -222,7 +282,7 @@ rollout runbook.
 | AppArmor + auditd | `custom.security.hardening.{apparmor,auditd}` | off (soak first) | Flip on after a clean soak; complain-first profiles |
 | USBGuard | `custom.security.hardening.usbguard` (preset `paranoid`) | off | Blocks newly-plugged USB; disruptive with Framework expansion cards |
 | Strict egress firewall | `networking.firewall.strictEgress` | **on, enforcing** | Default-deny outbound allowlist as a standalone nft `output` table (coexists with the ingress firewall + IP blocker). Flipped from dry-run to `recovery.dryRun = false` on the soaked `nixos` host allowlist (`preset = "developer"` + ollama/blipply-assistant/dcf-node-binary domains); `recovery.failOpen = true` still flushes the chain if `cache.nixos.org` becomes unreachable, so a bad allowlist can't brick a rebuild |
-| Malware Shield | `custom.malwareShield` (level `monitor`) | **on** | ClamAV + lynis/unhide + AIDE + YARA; log-only until you raise to `quarantine`. YARA walks via `find(1)` (no `-L`) to dodge symlink cycles. `custom.malwareShield.yara.excludePaths` skips e.g. Claude Code transcripts. Closure scanned at build via `nix build .#malwareScan` |
+| Malware Shield | `custom.malwareShield` (level `monitor`) | **on** | ClamAV + lynis/unhide + AIDE + YARA; log-only until you raise to `quarantine`. YARA walks via `find(1)` (no `-L`) to dodge symlink cycles. `custom.malwareShield.yara.excludePaths` skips known structural false positives: Claude Code transcripts, and this repo's own `modules/security/yara-rules/eicar.yar` + `docs/security-hardening.md` (both legitimately contain the EICAR test string — the rule *is* the EICAR test, and self-matches whenever a checkout of this repo lives under a scanned path). Closure scanned at build via `nix build .#malwareScan` |
 | Ingress IP blocklist | `services.demod-ip-blocker` | **on** | Refreshes every 24h |
 | Rootless Docker | `virtualisation.docker.rootless` | **on** | Daemon runs as the user; no root-equivalent `docker` group |
 | Secure Boot | `custom.secureBoot.enable` | off | lanzaboote signed chain + optional TPM2 LUKS |

--- a/docs/oligarchy-forge-roadmap.md
+++ b/docs/oligarchy-forge-roadmap.md
@@ -71,12 +71,41 @@ modules/oligarchy-forge/
 ### `forge-core` (`crates/forge-core/src/`)
 
 - `schema.rs` — `ForgeConfig`/`Project`/`Runtime`/`Backend`/`VolumeMode`/
-  `Extension`. `Extension::ALL` is the six built-ins:
+  `Extension`/`Agent`. `Extension::ALL` is the seven built-in toolchains:
   `base` (always implicit — bash, coreutils, git), `rust`, `python`,
-  `node`, `go`, `faust-jack` (nod to the Faust/JACK stack this distro
-  already ships via `demod-voice`/`ArchibaldOS`). Adding a seventh
+  `node`, `node-lts`, `go`, `faust-jack` (nod to the Faust/JACK stack this
+  distro already ships via `demod-voice`/`ArchibaldOS`). Adding another
   extension means adding one `Extension` variant + one `packages()` arm —
   nothing else.
+
+  `Agent::ALL` is the coding-agent-CLI catalog (`[project].agents` in
+  `oligarchy-forge.toml`, separate from `extensions` — an agent isn't a
+  toolchain, and `run -- <cmd>` stays free-form for anything not in this
+  catalog): `oh-my-pi`, `claude`, `opencode`, `ollama`, `codex`, `aider`,
+  `cursor`. Two shapes:
+  - **Plain nixpkgs package** (`opencode`, `ollama`, `codex`, `aider` →
+    `aider-chat`, `cursor` → `cursor-cli`): just an `Agent::packages()`
+    entry, `wrapper_script()` returns `""`. `cursor-cli` is nixpkgs-unfree,
+    which is why the generated flake's own `pkgs` sets
+    `config.allowUnfree = true` (matching the parent flake's own stance).
+  - **Custom wrapper** (`oh-my-pi`, `claude`): `wrapper_script()` returns a
+    Nix expression spliced into the generated flake's `contents` list.
+    `oh-my-pi` fetches a version-pinned Bun release and lazily installs the
+    npm package on first container run (nixpkgs' `bun` is too old for it).
+    `claude` isn't in nixpkgs at all (npm-only upstream) — sourced from the
+    community `github:sadjow/claude-code-nix` flake, referenced directly as
+    `claude-code-nix.packages.${system}.claude-code` rather than merged in
+    via that flake's overlay (avoids any nixpkgs-revision mismatch between
+    its own pinned `nixpkgs-unstable` and this template's `nixos-25.11`).
+    That extra flake input is only ever declared — and therefore only ever
+    fetched — when `claude` is actually selected for a project
+    (`Agent::needs_flake_input()` / `ForgeConfig::needs_claude_code_nix()`
+    gate a `{% if %}` block in `templates/flake.nix.tera`); a project that
+    never picks Claude never pays for it. Adding another plain-package
+    agent means one `Agent` variant + one `packages()` arm, same as an
+    extension; adding another flake-sourced agent additionally means a
+    `needs_flake_input()` arm and a second conditional input in the
+    template.
 - `render.rs` — `render_flake()`: Tera-renders the embedded
   `templates/flake.nix.tera` (via `include_str!`, no runtime path lookup)
   into a self-contained `flake.nix` defining
@@ -349,6 +378,30 @@ Status legend: `[ ]` pending · `[~]` in progress · `[x]` done · `[!]` blocked
 
 ## Changelog (living document — append newest at top)
 
+- **Agent catalog expanded (2026-08-16):** `Agent::ALL` grew from one
+  entry (`oh-my-pi`) to seven: `claude`, `opencode`, `ollama`, `codex`,
+  `aider`, `cursor` added. Five of the six new agents are plain nixpkgs
+  packages (one `packages()` arm each, no wrapper); `claude` isn't in
+  nixpkgs at all (npm-only upstream) and is sourced from the community
+  `github:sadjow/claude-code-nix` flake, referenced directly rather than
+  merged in via its overlay — that extra flake input is only ever declared
+  in the generated project flake (and therefore only ever fetched) when
+  `claude` is actually selected, via a `{% if %}` block in
+  `templates/flake.nix.tera` gated on `ForgeConfig::needs_claude_code_nix()`.
+  Real issues caught by actually building an image, not just `cargo test`:
+  (1) `cursor-cli` is nixpkgs-unfree; the generated flake's `pkgs` didn't
+  set `config.allowUnfree`, so `oligarchy-forge build` failed outright with
+  Cursor selected even though every unit test passed — fixed by matching
+  the parent Oligarchy flake's own "unfree + broken allowed" stance in the
+  template. (2) `#[serde(rename_all = "kebab-case")]`'s auto-derivation
+  would have produced the TOML key `"open-code"` for the one-word tool
+  `opencode` — caught by a test asserting the real command name, fixed
+  with an explicit `#[serde(rename = "opencode")]`. Verified end-to-end:
+  built a real sandbox image with all 7 agents selected, loaded it into
+  podman, and ran every agent's `--version` inside the running container
+  (`claude` 2.1.233, `codex-cli` 0.92.0, `aider` 0.86.1, `cursor-agent`
+  2025.11.06, `opencode` 1.1.14, `ollama` client 0.21.1, `omp`'s
+  lazy-install path triggering correctly).
 - **Phase 1 landed (2026-07-26):** `forge-tui` (session list + live build
   log) implemented, tested, and wired in as part of the existing
   `oligarchy-forge` binary rather than a second one. Real issues caught by


### PR DESCRIPTION
Documentation catch-up for the 5 PRs merged today (#15-#19): demod-talk, the theme-engine/control-center/QoL polish pass, the YARA excludePaths fix, the repo-update notifier, and the oligarchy-forge Agent catalog expansion.

- **`docs/architecture.md`**: documents live theme-switching (per-palette variant rendering, not just border colors), a new §7a for the control center (action registry, flat search, persona-menu, dcf-control, the forge-agent launcher), the waybar repo-update badge's actual verified behavior, and the malware-shield exclude-paths fix.
- **`docs/oligarchy-forge-roadmap.md`**: documents the Agent catalog going from 1 to 7 entries, the plain-nixpkgs vs. flake-input split, and a changelog entry noting what was verified end-to-end vs. unit-tested.
- **`README.md`**: two new feature bullets (live theme switching, unified command palette) and a first-ever mention of `oligarchy-forge` and its agent catalog.

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)