### PR TITLE
Add support for binary cachyos kernel from chaotic-nyx

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,6 +32,27 @@
       },
       "parent": []
     },
+    "chaotic": {
+      "inputs": {
+        "flake-schemas": "flake-schemas",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1787548813,
+        "narHash": "sha256-gJ4iHdxyghxoo30WuAo4aoiLKOk9XgnNfYBgvYrt25s=",
+        "owner": "chaotic-cx",
+        "repo": "nyx",
+        "rev": "14dcc33c77701e0f03dd25919e17f55bac55684d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "chaotic-cx",
+        "ref": "nyxpkgs-unstable",
+        "repo": "nyx",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1783203018,
@@ -49,7 +70,7 @@
     },
     "demod-ip-blocker": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1767837716,
@@ -85,7 +106,7 @@
       "inputs": {
         "flake-utils": "flake-utils_3",
         "hydramesh-src": "hydramesh-src",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "path": "./modules/demod-talk",
@@ -100,7 +121,7 @@
     "demod-voice": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "tinygrad": "tinygrad"
       },
       "locked": {
@@ -119,7 +140,7 @@
         "determinate-nixd-aarch64-linux": "determinate-nixd-aarch64-linux",
         "determinate-nixd-x86_64-linux": "determinate-nixd-x86_64-linux",
         "nix": "nix",
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1771014593,
@@ -173,7 +194,7 @@
     "dsp-ctl": {
       "inputs": {
         "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_9"
+        "nixpkgs": "nixpkgs_10"
       },
       "locked": {
         "path": "./modules/dsp-ctl",
@@ -239,6 +260,20 @@
       }
     },
     "flake-schemas": {
+      "locked": {
+        "lastModified": 1780327564,
+        "narHash": "sha256-HiRPtA0spK+Dkgbhz/1zW9glXxNVB+L4Rj2VYmdawb8=",
+        "rev": "6cc9bd98891b1fc6bb2b8cb3277df8bc72799ca6",
+        "revCount": 149,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.5.0/019e83cf-9af3-78b1-ac5b-70e68ad1efe1/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/flake-schemas/%3D0.5.0.tar.gz"
+      }
+    },
+    "flake-schemas_2": {
       "locked": {
         "lastModified": 1780327564,
         "narHash": "sha256-HiRPtA0spK+Dkgbhz/1zW9glXxNVB+L4Rj2VYmdawb8=",
@@ -461,7 +496,7 @@
     "greeting": {
       "inputs": {
         "flake-utils": "flake-utils_6",
-        "nixpkgs": "nixpkgs_10"
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
         "path": "./modules/greeting",
@@ -474,6 +509,27 @@
       "parent": []
     },
     "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "chaotic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787379775,
+        "narHash": "sha256-XL2qfqmocfsvuEGyomZg4nOZfkuSe8vZtrOX99I+b6I=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "ec1a8fdf74ed3f276148ee106299a2ba0e65d51f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -499,7 +555,7 @@
         "demod-quanta-src": "demod-quanta-src",
         "flake-utils": "flake-utils_7",
         "janus-c-src": "janus-c-src",
-        "nixpkgs": "nixpkgs_11",
+        "nixpkgs": "nixpkgs_12",
         "nixpkgs-faust": "nixpkgs-faust",
         "rust-overlay": "rust-overlay_3"
       },
@@ -575,7 +631,7 @@
     "mcp-servers": {
       "inputs": {
         "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_13",
+        "nixpkgs": "nixpkgs_14",
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
@@ -591,7 +647,7 @@
     "minecraft": {
       "inputs": {
         "flake-utils": "flake-utils_9",
-        "nixpkgs": "nixpkgs_14"
+        "nixpkgs": "nixpkgs_15"
       },
       "locked": {
         "path": "./modules/minecraft",
@@ -607,7 +663,7 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-regression": "nixpkgs-regression"
       },
@@ -757,6 +813,22 @@
     },
     "nixpkgs_10": {
       "locked": {
+        "lastModified": 1784007870,
+        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
         "lastModified": 1784497964,
         "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
@@ -771,7 +843,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_11": {
+    "nixpkgs_12": {
       "locked": {
         "lastModified": 1767640445,
         "narHash": "sha256-UWYqmD7JFBEDBHWYcqE6s6c77pWdcU/i+bwD6XxMb8A=",
@@ -787,7 +859,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_12": {
+    "nixpkgs_13": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -803,7 +875,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_13": {
+    "nixpkgs_14": {
       "locked": {
         "lastModified": 1784796856,
         "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
@@ -819,7 +891,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_14": {
+    "nixpkgs_15": {
       "locked": {
         "lastModified": 1785571196,
         "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
@@ -835,7 +907,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_15": {
+    "nixpkgs_16": {
       "locked": {
         "lastModified": 1780952837,
         "narHash": "sha256-Fwd1+spDtQ0hDyBwme6ufG3n4mY0UrjjFdYHv+G/Hds=",
@@ -851,7 +923,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_16": {
+    "nixpkgs_17": {
       "locked": {
         "lastModified": 1784796856,
         "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
@@ -867,7 +939,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_17": {
+    "nixpkgs_18": {
       "locked": {
         "lastModified": 1784497964,
         "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
@@ -883,7 +955,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_18": {
+    "nixpkgs_19": {
       "locked": {
         "lastModified": 1781074563,
         "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
@@ -933,6 +1005,22 @@
     },
     "nixpkgs_4": {
       "locked": {
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
         "lastModified": 1771008912,
         "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "nixos",
@@ -947,7 +1035,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1786862985,
         "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
@@ -963,7 +1051,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1769461804,
         "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
@@ -979,7 +1067,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1761597516,
         "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
@@ -993,7 +1081,7 @@
         "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2505"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_9": {
       "locked": {
         "lastModified": 1770537093,
         "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
@@ -1007,26 +1095,10 @@
         "url": "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1"
       }
     },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1784007870,
-        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "oligarchy-forge": {
       "inputs": {
         "flake-utils": "flake-utils_10",
-        "nixpkgs": "nixpkgs_16"
+        "nixpkgs": "nixpkgs_17"
       },
       "locked": {
         "path": "./modules/oligarchy-forge",
@@ -1062,8 +1134,8 @@
     },
     "quickemu": {
       "inputs": {
-        "flake-schemas": "flake-schemas",
-        "nixpkgs": "nixpkgs_18"
+        "flake-schemas": "flake-schemas_2",
+        "nixpkgs": "nixpkgs_19"
       },
       "locked": {
         "lastModified": 1781877181,
@@ -1083,20 +1155,21 @@
       "inputs": {
         "blipply-assistant": "blipply-assistant",
         "boot-intro": "boot-intro",
+        "chaotic": "chaotic",
         "demod-ip-blocker": "demod-ip-blocker",
         "demod-talk": "demod-talk",
         "demod-voice": "demod-voice",
         "determinate": "determinate",
         "dsp-ctl": "dsp-ctl",
         "greeting": "greeting",
-        "home-manager": "home-manager",
+        "home-manager": "home-manager_2",
         "hydramesh": "hydramesh",
         "lanzaboote": "lanzaboote",
         "mcp-servers": "mcp-servers",
         "minecraft": "minecraft",
         "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_15",
+        "nixpkgs": "nixpkgs_16",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "oligarchy-forge": "oligarchy-forge",
         "sops-nix": "sops-nix",
@@ -1145,7 +1218,7 @@
     },
     "rust-overlay_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_12"
+        "nixpkgs": "nixpkgs_13"
       },
       "locked": {
         "lastModified": 1782012058,
@@ -1391,7 +1464,7 @@
     },
     "vm-manager": {
       "inputs": {
-        "nixpkgs": "nixpkgs_17",
+        "nixpkgs": "nixpkgs_18",
         "quickemu": "quickemu"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,9 @@
     # Determinate Systems enhancements
     determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/*";
 
+    # Chaotic-Nyx - bleeding edge packages, pre-built CachyOS kernels & binary cache
+    chaotic.url = "github:chaotic-cx/nyx/nyxpkgs-unstable";
+
     # Hardware support
     nixos-hardware.url = "github:NixOS/nixos-hardware";
 
@@ -109,6 +112,7 @@
     { self
     , nixpkgs
     , nixpkgs-unstable
+    , chaotic
     , determinate
     , nixos-hardware
     , demod-ip-blocker
@@ -150,7 +154,7 @@
 
       # Common specialArgs passed to all modules
       specialArgs = {
-        inherit inputs nixpkgs-unstable;
+        inherit inputs nixpkgs-unstable chaotic;
         # Uncomment when archibaldos is available:
         # inherit archibaldos;
         inherit vm-manager dsp-ctl oligarchy-forge mcp-servers hydramesh;
@@ -170,6 +174,7 @@
         { nixpkgs.config = pkgsConfig; }
 
         # Third-party modules (board-specific hardware modules live per-host below)
+        chaotic.nixosModules.default
         determinate.nixosModules.default
         sops-nix.nixosModules.sops
         demod-ip-blocker.nixosModules.default

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -4,15 +4,16 @@
 # Optimized Kernel Module for Framework 16 AMD
 # ============================================================================
 #
-# Default: Zen kernel (pre-built, immediate availability)
-#   - Low-latency scheduler optimizations
-#   - Gaming and audio production optimized
-#   - MuQSS scheduler
+# Pre-built kernels (Immediate availability via nixpkgs / Chaotic-Nyx):
+#   - cachyos: CachyOS kernel with BORE scheduler (pre-built from Chaotic-Nyx)
+#   - cachyos-lto: CachyOS kernel with LTO optimizations (pre-built from Chaotic-Nyx)
+#   - zen: Zen kernel (pre-built from nixpkgs)
+#   - xanmod: XanMod kernel with BORE scheduler (pre-built from nixpkgs)
+#   - latest: Latest stable upstream Linux kernel (pre-built from nixpkgs)
+#   - lts: Linux 6.12 LTS (pre-built from nixpkgs)
 #
-# Alternative: CachyOS BORE (requires building from source)
-#   - Set kernelChoice = "cachyos-bore"
-#   - Update the sha256 hashes below
-#   - First build will take 30-60 minutes
+# Source-built kernel:
+#   - cachyos-bore: Build CachyOS BORE from source (requires allowCachyExperimental + hashes)
 #
 # ============================================================================
 
@@ -20,9 +21,9 @@ let
   # ─────────────────────────────────────────────────────────────────────────
   # KERNEL SELECTION
   # ─────────────────────────────────────────────────────────────────────────
-  # Variant is now a declarative option: custom.kernel.variant
-  # ("zen" | "xanmod" | "latest" | "lts" | "cachyos-bore"). Set it in
-  # configuration.nix or via the control center (writes
+  # Variant is a declarative option: custom.kernel.variant
+  # ("cachyos" | "cachyos-lto" | "cachyos-bore" | "zen" | "xanmod" | "latest" | "lts").
+  # Set it in configuration.nix or via the control center (writes
   # ~/.config/oligarchy/state.nix).
   cfg = config.custom.kernel;
 
@@ -71,46 +72,41 @@ let
     '';
 
   # ─────────────────────────────────────────────────────────────────────────
-  # CachyOS BORE Configuration (only if kernelChoice = "cachyos-bore")
+  # CachyOS BORE (Source Build Configuration for variant = "cachyos-bore")
   # ─────────────────────────────────────────────────────────────────────────
-  # To get correct hashes:
-  #   1. Set sha256 to lib.fakeHash
-  #   2. Run: nix build .#nixosConfigurations.nixos.config.system.build.toplevel 2>&1 | grep 'got:'
-  #   3. Copy the correct hash
-  
   cachyosVersion = "6.12.10";
   cachyosDir = "6.12";
-  
+
   # Kernel source
   cachyos-src = pkgs.fetchurl {
     url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${cachyosVersion}.tar.xz";
-    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";  # Replace with actual hash
+    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; # Replace with actual hash
   };
-  
+
   # CachyOS defconfig
   cachyos-config = pkgs.fetchurl {
     url = "https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos-bore/config";
-    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";  # Replace with actual hash
+    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; # Replace with actual hash
   };
-  
+
   # CachyOS patches
   cachyos-patches = [
     {
       name = "cachyos-base-all";
       patch = pkgs.fetchpatch {
         url = "https://raw.githubusercontent.com/cachyos/kernel-patches/master/${cachyosDir}/all/0001-cachyos-base-all.patch";
-        sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";  # Replace with actual hash
+        sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; # Replace with actual hash
       };
     }
     {
       name = "bore-scheduler";
       patch = pkgs.fetchpatch {
         url = "https://raw.githubusercontent.com/cachyos/kernel-patches/master/${cachyosDir}/sched/0001-bore-cachy.patch";
-        sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";  # Replace with actual hash
+        sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; # Replace with actual hash
       };
     }
   ];
-  
+
   # Build CachyOS kernel
   cachyos-kernel = (pkgs.linuxManualConfig {
     inherit (pkgs) stdenv;
@@ -131,28 +127,23 @@ let
   # Kernel Selection Map
   # ─────────────────────────────────────────────────────────────────────────
   kernelPackagesMap = {
+    # CachyOS: from Chaotic-Nyx (includes BORE scheduler by default)
+    "cachyos" = pkgs.linuxPackages_cachyos;
+    "cachyos-lto" = pkgs.linuxPackages_cachyos-lto;
+
     # Zen: Optimized for desktop, gaming, audio. Pre-built.
     "zen" = pkgs.linuxPackages_zen;
-    
+
     # Xanmod: Uses BORE scheduler. Pre-built.
     "xanmod" = pkgs.linuxPackages_xanmod_latest;
-    
+
     # Latest stable kernel
     "latest" = pkgs.linuxPackages_latest;
 
-    # LTS: nixpkgs' current long-term-support line. Pre-built, most
-    # predictable RT/audio behavior of the four (no rolling scheduler
-    # patches). Pins to linuxPackages_6_12 (Linux 6.12 LTS, upstream EOL
-    # projected Dec 2028 — see the kernelEol* warning above). NOTE: unlike
-    # "latest" (nixpkgs itself keeps linuxPackages_latest pointed at the
-    # newest stable kernel), nixpkgs has no generic "linuxPackages_lts" /
-    # "linuxPackages_default" alias to bind to — this entry is a manually
-    # pinned attribute and MUST be bumped by hand (e.g. to linuxPackages_6_1X,
-    # or renamed to "lts-6.1X") once nixpkgs rolls its own LTS default past
-    # 6.12.
+    # LTS: Linux 6.12 LTS
     "lts" = pkgs.linuxPackages_6_12;
 
-    # CachyOS BORE (requires hash updates above)
+    # Custom CachyOS BORE built from source
     "cachyos-bore" = pkgs.linuxPackagesFor cachyos-kernel;
   };
 
@@ -161,20 +152,18 @@ let
 in {
   options.custom.kernel = {
     variant = lib.mkOption {
-      type = lib.types.enum [ "zen" "xanmod" "latest" "lts" "cachyos-bore" ];
+      type = lib.types.enum [ "zen" "cachyos" "cachyos-lto" "cachyos-bore" "xanmod" "latest" "lts" ];
       default = "zen";
       description = ''
-        Kernel package set. zen/xanmod/latest/lts are pre-built; cachyos-bore
-        is built from source (heavy) and requires allowCachyExperimental +
-        real hashes filled into the cachyos-* fetchers in this module.
+        Kernel package set.
 
-        lts pins to pkgs.linuxPackages_6_12 (Linux 6.12 LTS). It trades the
-        zen/xanmod rolling schedulers for a long-term-support branch with
-        more predictable RT/audio latency behavior — used by the "studio"
-        persona for this reason. Linux 6.12's upstream EOL is currently
-        projected for December 2028; this module emits a build-time warning
-        (not a hard failure) once the nixpkgs pin's own commit date reaches
-        that cutoff — see the kernelEol* let-bindings above.
+        zen / xanmod / latest / lts: Pre-built kernels from nixpkgs (zen is default).
+
+        cachyos / cachyos-lto: Pre-built CachyOS kernels from Chaotic-Nyx
+        (cachyos includes the BORE scheduler and upstream CachyOS optimizations).
+
+        cachyos-bore: Built from source (heavy) and requires allowCachyExperimental +
+        real hashes filled into the cachyos-* fetchers in this module.
       '';
     };
 
@@ -213,21 +202,21 @@ in {
     # Desktop/Gaming Optimized Sysctl
     # ───────────────────────────────────────────────────────────────────────
     boot.kernel.sysctl = {
-    # Memory management
-    "vm.swappiness" = lib.mkDefault 10;
-    "vm.dirty_ratio" = lib.mkDefault 10;
-    "vm.dirty_background_ratio" = lib.mkDefault 5;
-    "vm.vfs_cache_pressure" = lib.mkDefault 50;
-    
-    # Network performance
-    "net.core.rmem_default" = lib.mkDefault 1048576;
-    "net.core.wmem_default" = lib.mkDefault 1048576;
-    "net.core.rmem_max" = lib.mkDefault 16777216;
-    "net.core.wmem_max" = lib.mkDefault 16777216;
-    "net.ipv4.tcp_fastopen" = lib.mkDefault 3;
-    
-    # Real-time audio
-    "kernel.sched_rt_runtime_us" = lib.mkDefault 950000;
+      # Memory management
+      "vm.swappiness" = lib.mkDefault 10;
+      "vm.dirty_ratio" = lib.mkDefault 10;
+      "vm.dirty_background_ratio" = lib.mkDefault 5;
+      "vm.vfs_cache_pressure" = lib.mkDefault 50;
+
+      # Network performance
+      "net.core.rmem_default" = lib.mkDefault 1048576;
+      "net.core.wmem_default" = lib.mkDefault 1048576;
+      "net.core.rmem_max" = lib.mkDefault 16777216;
+      "net.core.wmem_max" = lib.mkDefault 16777216;
+      "net.ipv4.tcp_fastopen" = lib.mkDefault 3;
+
+      # Real-time audio
+      "kernel.sched_rt_runtime_us" = lib.mkDefault 950000;
     };
   };
 }


### PR DESCRIPTION
This should work as expected.

Also keeps support for the source-built kernel.

The binary cache comes from chaotic-nyx