### PR TITLE
fix(lock): stop hyprlock rendering on the dGPU; bound shutdown stops

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -187,7 +187,9 @@
         domain = "dcf.demod.ltd";
         port = 4000;
         dataDir = "/var/lib/demod-identity";
-        secretsFile = "/etc/nixos/secrets/dcf-id.env";
+        # When enabling: sops runtime path, NEVER a repo file (that copies
+        # into /nix/store). See modules/dcf-identity.nix secretsFile docs.
+        secretsFile = "/run/secrets/dcf-id-env";
       };
       # System Tray Controller
       services.dcf-tray.enable = false;
@@ -427,14 +429,29 @@
       programs.steam = lib.mkIf config.custom.steam.enable {
         enable = true;
         extraCompatPackages = [ pkgs.proton-ge-bin ];
-        # Only force dGPU routing when custom.platform.displayGpu = "dgpu"
-        # (the default) and this host actually has a dGPU to route to — see
-        # modules/platform.nix and docs/dgpu-steam-forcing.md.
-        package = lib.mkIf (config.custom.platform.hasDgpu && config.custom.platform.displayGpu == "dgpu") (pkgs.steam.override {
+        # These have to live in Steam's FHS, not just on PATH. A host
+        # mangohud/gamescope is invisible to pressure-vessel otherwise, so
+        # launch options like `mangohud %command%` / `gamescope -- %command%`
+        # silently do nothing.
+        extraPackages = with pkgs; [ gamescope mangohud ];
+        remotePlay.openFirewall = true;
+        localNetworkGameTransfers.openFirewall = true;
+        # Steam Input on Wayland: translate X11 events to uinput so controllers
+        # and Steam's overlay bindings actually reach games under Hyprland.
+        extest.enable = true;
+        protontricks.enable = true;
+        # extraEnv always — scaling is independent of which GPU renders.
+        # DRI_PRIME only when this host has a dGPU and displayGpu = "dgpu"
+        # (see modules/platform.nix and docs/dgpu-steam-forcing.md).
+        package = pkgs.steam.override {
           extraEnv = {
+            # Framework 16 2560x1600 @ scale 1: Steam's UI is unreadably small
+            # at 1.0. 1.25 is sharp enough not to look like a bitmap stretch.
+            STEAM_FORCE_DESKTOPUI_SCALING = "1.25";
+          } // lib.optionalAttrs (config.custom.platform.hasDgpu && config.custom.platform.displayGpu == "dgpu") {
             DRI_PRIME = "pci-" + lib.replaceStrings [ ":" "." ] [ "_" "_" ] config.custom.platform.dgpuPciId;
           };
-        });
+        };
       };
       hardware.steam-hardware.enable = lib.mkIf config.custom.steam.enable true;
       # gamemode is owned by the active persona (on for the "gaming" persona).
@@ -455,11 +472,19 @@
       # ──────────────────────────────────────────────────────────────────────────
       custom.vm.dsp = {
         enable = lib.mkDefault false;
-        # Do NOT autostart at boot: the guest currently spins at 100% CPU on the
-        # isolated cores and never boots (OVMF firmware not wired into the qemu
-        # launch + no guest serial console), which soft-locks the host. Units
-        # stay defined for manual launch (systemctl start archibaldos-dsp) while
-        # the boot path is fixed. Flip back to true once the guest boots cleanly.
+        # Do NOT autostart at boot, and this is now a policy choice rather than
+        # a workaround. Starting the VM binds the second xHCI controller to
+        # vfio-pci and hands it to the guest, so every audio interface on that
+        # bus disappears from the host mid-session. That has to be deliberate.
+        #
+        # The old reason recorded here — "OVMF firmware not wired into the qemu
+        # launch + no guest serial console" — was wrong on the first count and
+        # is fixed on the second. OVMF was already wired in (`cfg.ovmf`, on by
+        # default). What actually spun the isolated cores at 100% was the disk:
+        # a hand-copied qcow2 with no EFI system partition, so OVMF found
+        # nothing to boot and fell through to an endless PXE netboot loop. The
+        # image is a derivation now (`nix build .#dsp-vm-qcow`, wired up in
+        # flake.nix) and the console is a real socket, so `dsp-console` works.
         autoStart = false;
         name = "archibaldos-dsp";
         isolatedCores = [ 0 1 ];
@@ -689,7 +714,10 @@
             "ProtectKernelLogs=yes"
             "ProtectKernelModules=yes"
             "ProtectControlGroups=yes"
-            "ProtectHome=yes"
+            # ProtectHome is deliberately absent: Steam's library, shader
+            # cache, and compat prefixes live under ~/.steam and
+            # ~/.local/share/Steam. Hiding $HOME makes every launch look like
+            # a first-run (or fail outright).
             "LockPersonality=yes"
           ];
           steamNoSwapLauncher = pkgs.writeShellScript "steam-noswap" ''
@@ -1002,6 +1030,32 @@
       # docker -> multi-user.target hostage for 30s every boot.
       systemd.services.NetworkManager-wait-online.enable = lib.mkForce false;
 
+      # Shutdown timeout backstop. The stock 90s system / 90s user defaults let
+      # a SINGLE process stuck in an uninterruptible kernel path cost 3m44s of
+      # poweroff (hyprlock wedged in an amdgpu/TTM ioctl: 90s in hypridle's
+      # stop, then 2min of user@1000 stop-sigterm, then 2min more after the
+      # final SIGKILL). The fix for that specific process is elsewhere -- this
+      # is the backstop, so the NEXT stuck process costs seconds instead.
+      # Truncating a .swap stop is harmless at poweroff: the contents are
+      # discarded either way. `systemd.extraConfig` is a removed option; the
+      # system manager is configured via settings.Manager, the user manager
+      # still via a lines-typed extraConfig.
+      systemd.settings.Manager.DefaultTimeoutStopSec = "10s";
+      systemd.user.extraConfig = "DefaultTimeoutStopSec=10s\n";
+
+      # libvirt-guests ships TimeoutStopSec=0 -- literally infinity -- with
+      # ON_SHUTDOWN=suspend and SHUTDOWN_TIMEOUT=300 per guest, serialised.
+      # It is free today only because zero domains exist (it stops in 67ms);
+      # defining one arms an unbounded wait. Bound both halves. This is a
+      # timeout backstop, not a decision to stop using libvirt.
+      virtualisation.libvirtd.shutdownTimeout = 30;
+      # Guarded: the NixOS module only defines libvirt-guests when libvirtd is
+      # enabled (it is here only because local.nix sets custom.vm.dsp.enable).
+      # Unguarded this would synthesise a stub unit with no ExecStart on a
+      # fresh clone.
+      systemd.services.libvirt-guests.serviceConfig.TimeoutStopSec =
+        lib.mkIf config.virtualisation.libvirtd.enable 60;
+
       # Astrill VPN egress list -> demod-blk-v4/v6. VPN detection, not threat
       # intel; the blocklists module below carries the actual threat feeds.
       services.demod-ip-blocker = {
@@ -1194,7 +1248,15 @@
           login = { fprintAuth = true; enableGnomeKeyring = true; };
           sudo = { fprintAuth = true; };
           greetd = { enableGnomeKeyring = true; };
-          hyprlock = { fprintAuth = true; enableGnomeKeyring = true; };
+          # fprintAuth is OFF here on purpose. pam_fprintd lands FIRST and
+          # `sufficient` in /etc/pam.d/hyprlock, but no fingers are enrolled on
+          # the Goodix sensor -- so every single lock D-Bus-activated fprintd
+          # and sat on it for ~30s, buying nothing: hyprlock's own
+          # auth:fingerprint:enabled defaults off, so the reader never drove
+          # the UI anyway. To actually use it, flip this back to true AND set
+          # auth:fingerprint:enabled in home/apps/hyprlock.nix -- both, or it
+          # regresses to the same dead leg.
+          hyprlock = { fprintAuth = false; enableGnomeKeyring = true; };
         };
 
 

--- a/home/apps/control-center/oligarchy-ctl.sh
+++ b/home/apps/control-center/oligarchy-ctl.sh
@@ -355,7 +355,7 @@ run() {
     power-perf)     powerprofilesctl set performance && note "Power → performance" ;;
     power-balanced) powerprofilesctl set balanced && note "Power → balanced" ;;
     power-saver)    powerprofilesctl set power-saver && note "Power → power-saver" ;;
-    lock)           hyprlock ;;
+    lock)           systemctl --user start --no-block hyprlock.service ;;
     logout)         wlogout -p layer-shell ;;
 
     sys-status)     visible bash -c 'oligarchy-ctl status' ;;

--- a/home/apps/desktop-entries.nix
+++ b/home/apps/desktop-entries.nix
@@ -15,12 +15,14 @@ let
     "ProtectKernelLogs=yes"
     "ProtectKernelModules=yes"
     "ProtectControlGroups=yes"
-    "ProtectHome=yes"
+    # ProtectHome is deliberately absent: Steam's library lives in $HOME.
     "LockPersonality=yes"
   ];
-  steamExec = "${pkgs.systemd}/bin/systemd-run --user --collect --slice=steam-noswap.slice --description=steam-hardened "
+  mkSteamExec = args:
+    "${pkgs.systemd}/bin/systemd-run --user --collect --slice=steam-noswap.slice --description=steam-hardened "
     + lib.concatMapStringsSep " " (p: "-p ${p}") steamHardeningProps
-    + " -- /run/current-system/sw/bin/steam %U";
+    + " -- /run/current-system/sw/bin/steam" + args;
+  steamExec = mkSteamExec " %U";
 in
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -71,12 +73,30 @@ in
   home.file.".local/share/applications/steam.desktop".text = ''
     [Desktop Entry]
     Name=Steam
+    Comment=Valve Steam
     Icon=steam
     Exec=${steamExec}
     Terminal=false
     Type=Application
     Categories=Network;FileTransfer;Game;
-    MimeType=x-scheme-handler/steam;
+    MimeType=x-scheme-handler/steam;x-scheme-handler/steamlink;
+    Actions=Library;BigPicture;Friends;
+    PrefersNonDefaultGPU=true
+    X-KDE-RunOnDiscreteGpu=true
+    StartupNotify=true
+    StartupWMClass=steam
+
+    [Desktop Action Library]
+    Name=Library
+    Exec=${mkSteamExec " steam://open/games"}
+
+    [Desktop Action BigPicture]
+    Name=Big Picture
+    Exec=${mkSteamExec " -gamepadui"}
+
+    [Desktop Action Friends]
+    Name=Friends
+    Exec=${mkSteamExec " steam://open/friends"}
   '';
 
   home.file.".local/share/applications/dsp-status.desktop".text = ''

--- a/home/apps/hyprlock.nix
+++ b/home/apps/hyprlock.nix
@@ -6,14 +6,27 @@ let
   # See home/apps/wofi.nix for why this is factored into a function of `p`.
   renderConf = p: ''
     general {
-      disable_loading_bar = false
       hide_cursor = true
-      grace = 3
+      # Draw immediately instead of waiting on background resources. Without
+      # this the lock surface is not finished (and so never becomes the
+      # keyboard focus) until its background resolves -- which is exactly what
+      # fails across a dpms-off/resume cycle. `disable_loading_bar` and `grace`
+      # used to live here and were REMOVED in hyprlock 0.9.x: they parsed as
+      # "config option does not exist" errors on every single lock, and `grace`
+      # silently did nothing. Grace is a CLI flag now, passed in the
+      # hyprlock.service ExecStart (see home/hyprland/default.nix).
+      immediate_render = true
     }
 
     background {
       monitor =
-      path = screenshot
+      # NOT `screenshot`. That routes the background through screencopy ->
+      # dmabuf import, which (a) cannot complete against an output that dpms
+      # tore down, leaving a lock surface that never takes the keyboard, and
+      # (b) is the amdgpu/TTM path hyprlock wedged in uninterruptibly -- a
+      # process SIGKILL cannot touch, which cost one shutdown 3m44s. Blur over
+      # a static image is a one-shot GL cost and needs neither.
+      path = ~/.config/hypr/wallpapers/default.jpg
       blur_passes = 4
       blur_size = 10
       brightness = 0.6

--- a/home/apps/wlogout.nix
+++ b/home/apps/wlogout.nix
@@ -7,7 +7,7 @@ in {
   # Wlogout Power Menu Configuration
   # ══════════════════════════════════════════════════════════════════════════
   home.file.".config/wlogout/layout".text = ''
-    {"label":"lock","action":"hyprlock","text":"Lock","keybind":"l"}
+    {"label":"lock","action":"systemctl --user start --no-block hyprlock.service","text":"Lock","keybind":"l"}
     {"label":"logout","action":"hyprctl dispatch exit","text":"Logout","keybind":"e"}
     {"label":"suspend","action":"systemctl suspend","text":"Sleep","keybind":"s"}
     {"label":"hibernate","action":"systemctl hibernate","text":"Hibernate","keybind":"h"}

--- a/home/hyprland/default.nix
+++ b/home/hyprland/default.nix
@@ -174,7 +174,7 @@ in
         "HYPRCURSOR_THEME,idTech4"
 
         # Gaming - VRR & Performance (only when gaming enabled)
-        (lib.optional (features.enableGaming or false) "STEAM_FORCE_DESKTOPUI_SCALING,1")
+        (lib.optional (features.enableGaming or false) "STEAM_FORCE_DESKTOPUI_SCALING,1.25")
         (lib.optional (features.enableGaming or false) "__GL_GSYNC_ALLOWED,1")
         (lib.optional (features.enableGaming or false) "__GL_VRR_ALLOWED,1")
 
@@ -459,7 +459,7 @@ in
 
         # Session
         "$mod, Escape, exec, wlogout -p layer-shell"
-        "$mod CTRL, L, exec, hyprlock"
+        "$mod CTRL, L, exec, systemctl --user start --no-block hyprlock.service"
         "$mod SHIFT, Escape, exit"
 
         # Theme switching
@@ -565,7 +565,9 @@ in
         "workspace 2, class:^(Code|code-url-handler)$"
         "workspace 3, class:^(obsidian)$"
         "workspace 5, class:^(thunderbird|discord)$"
-        "workspace 9 silent, class:^(steam)$"
+        # No `silent`: launching Steam used to dump it on ws 9 without
+        # switching, so the click looked like a no-op. Follow the client.
+        "workspace 9, class:^(steam)$"
         "float, class:^(steam)$, title:^(Friends|Settings|Screenshot).*$"
 
         # Gaming - Steam
@@ -586,8 +588,9 @@ in
         "noshadow, class:^(gamescope)$"
 
         # Gaming - Wine/Proton (immediate rendering, no effects)
+        # Do not force fullscreen: that double-fullscreens games that already
+        # set their own mode and also catches Proton config/overlay windows.
         "immediate, class:^(steam_app_.*)$"
-        "fullscreen, class:^(steam_app_.*)$, title:^(?!.*Settings).*$"
         "noblur, class:^(steam_app_.*)$"
         "noshadow, class:^(steam_app_.*)$"
         "idleinhibit always, class:^(steam_app_.*)$"
@@ -715,6 +718,10 @@ in
           ExecStart = execStart;
           Restart = "on-failure";
           RestartSec = 2;
+          # Nothing here is worth 90s of a shutdown. The default let one stuck
+          # child (hyprlock, in hypridle's cgroup) burn 90s here and then a
+          # further 2min+2min in user@1000 -- a 3m44s poweroff.
+          TimeoutStopSec = "10s";
         };
         Install.WantedBy = [ "hyprland-session.target" ];
       };
@@ -727,6 +734,46 @@ in
       hypridle = mkSessionService {
         description = "Hyprland idle daemon (dim/lock/suspend ladder)";
         execStart = "${pkgs.hypridle}/bin/hypridle";
+      };
+      # The locker is deliberately NOT a mkSessionService: it has no
+      # Install.WantedBy because it is started on demand, and it must not be
+      # `Restart`ed. Two reasons it is a unit at all rather than a bare command:
+      #
+      #  - It gets its own cgroup. Spawned as hypridle's child it inherited
+      #    hypridle's (KillMode=control-group), so a hyprlock stuck in an
+      #    uninterruptible amdgpu ioctl held hypridle's stop, then user@1000's.
+      #  - `systemctl start` on an active unit is a no-op, which is what
+      #    `pidof hyprlock || hyprlock` was reaching for and got wrong: pidof
+      #    also matches a hyprlock that is present but dead, and then the lock
+      #    is silently SKIPPED. That happened three times in one day.
+      #
+      # `grace` is an ExecStart flag because hyprlock 0.9.x removed the config
+      # key; see the comment in home/apps/hyprlock.nix.
+      hyprlock = {
+        Unit = {
+          Description = "Hyprland screen locker";
+          After = [ "hyprland-session.target" ];
+          PartOf = [ "hyprland-session.target" ];
+        };
+        Service = {
+          Type = "exec";
+          ExecStart = "${pkgs.hyprlock}/bin/hyprlock --grace 3";
+          Restart = "no";
+          TimeoutStopSec = "5s";
+          KillMode = "mixed";
+          # The locker renders where the COMPOSITOR renders, not where games
+          # do. gpuEnv above is documented as "client-app device selection
+          # ONLY", but `env=` in hyprland.conf also lands in the systemd user
+          # manager's environment, so every user unit silently inherited
+          # DRI_PRIME -- and every hyprlock in the journal was on the dGPU
+          # (amdgpu 0000:03:00.0). A full-screen blur on the dGPU over a
+          # dmabuf the compositor produced on the iGPU is a cross-device
+          # import, which is what dragged it into TTM buffer migration
+          # (ttm_bo_move_memcpy -> amdgpu_bo_move) and wedged it there
+          # uninterruptibly. Unset rather than pin: Mesa's default is already
+          # the compositor's device, and this stays correct on iGPU-only hosts.
+          UnsetEnvironment = "DRI_PRIME";
+        };
       };
       mako = mkSessionService {
         description = "Mako notification daemon";
@@ -760,7 +807,7 @@ in
   # suspends once the machine is actually idle and cool; on-resume cancels it.
   home.file.".config/hypr/hypridle.conf".text = ''
     general {
-      lock_cmd = pidof hyprlock || hyprlock
+      lock_cmd = systemctl --user start --no-block hyprlock.service
       before_sleep_cmd = loginctl lock-session
       after_sleep_cmd = hyprctl dispatch dpms on
       ignore_dbus_inhibit = false

--- a/home/scripts/panic.sh
+++ b/home/scripts/panic.sh
@@ -25,5 +25,6 @@ fi
 
 notify "locked · mic muted · clipboard wiped${radios}"
 
-# 4. Lock last (blocking).
-pidof hyprlock >/dev/null 2>&1 || hyprlock
+# 4. Lock last (blocking). No --no-block here on purpose: a panic lock that
+# returns before the locker is actually up is a panic lock that failed.
+systemctl --user start hyprlock.service

--- a/modules/oligarchy-plugins/modules/plugins.nix
+++ b/modules/oligarchy-plugins/modules/plugins.nix
@@ -868,6 +868,15 @@ in
               Restart = "on-failure";
               RestartSec = 2;
 
+              # PARTIAL mitigation, deliberately recorded as such: this bounds an
+              # ordinary hung stop, but it does NOT close the EXTEND_TIMEOUT_USEC
+              # gap. Tier-1 plugins require NotifyAccess=all (bwrap forks the
+              # process that reports ready -- see the landmine in CLAUDE.md and
+              # docs/plugins-roadmap.md), and a unit with NotifyAccess=all can
+              # extend past TimeoutStopSec indefinitely, with no systemd-side cap.
+              # Latent while declaredPlugins is empty; the real fix is gap-tracked.
+              TimeoutStopSec = "20s";
+
               # The supervisor's OWN runtime directory, not the one the plugin
               # instances share. systemd chowns a RuntimeDirectory to the unit's
               # User and deletes it when the unit stops, so a socket living in the
@@ -961,6 +970,15 @@ in
               Group = cfg.group;
               Restart = "on-failure";
               RestartSec = 5;
+
+              # PARTIAL mitigation, deliberately recorded as such: this bounds an
+              # ordinary hung stop, but it does NOT close the EXTEND_TIMEOUT_USEC
+              # gap. Tier-1 plugins require NotifyAccess=all (bwrap forks the
+              # process that reports ready -- see the landmine in CLAUDE.md and
+              # docs/plugins-roadmap.md), and a unit with NotifyAccess=all can
+              # extend past TimeoutStopSec indefinitely, with no systemd-side cap.
+              # Latent while declaredPlugins is empty; the real fix is gap-tracked.
+              TimeoutStopSec = "20s";
 
               StateDirectory = "oligarchy/plugins";
               # Match the tmpfiles rules below; systemd's default is 0755, which


### PR DESCRIPTION
## What was wrong

The auto-lock screen came up but never took the keyboard once the display had
blanked or the machine had suspended — so the password could not be typed in.
Separately, one poweroff took **3m44s** against a 14–22s baseline.

Same process both times, and the root cause is device routing, not the locker.

`DRI_PRIME` is documented in `home/hyprland/default.nix` as *"client-app device
selection ONLY"* — correct intent, but `env=` in `hyprland.conf` **also lands in
the systemd user manager's environment**, so every user unit inherited it:

```
$ systemctl --user show-environment | grep DRI_PRIME
DRI_PRIME=pci-0000_03_00_0      # the dGPU
```

Every `hyprlock` in the journal, going back weeks, ran on `amdgpu 0000:03:00.0`.
So the locker was doing a full-screen 4-pass blur **on the dGPU** over a
screencopy dmabuf the compositor produced **on the iGPU**. That cross-device
import is what dragged it into TTM buffer migration:

```
WARNING ttm_bo_move_sync_cleanup ... hyprlock:cs0
  amdgpu_cs_ioctl -> amdgpu_cs_parser_bos -> ttm_bo_validate -> amdgpu_bo_move
```

A process stuck there cannot be `SIGKILL`ed. That is the entire shutdown cost:
90s in hypridle's stop (hyprlock was its cgroup child), 2min of `user@1000`
stop-sigterm, then 2min more after the final SIGKILL. **Nothing VM-related
contributed** — `libvirt-guests` stopped in 67ms.

## Changes

| | |
|---|---|
| `UnsetEnvironment=DRI_PRIME` on `hyprlock.service` | The locker renders where the compositor does. Unset, not pinned to the iGPU, so it stays correct on iGPU-only hosts. **Games are unaffected** — `DRI_PRIME` still reaches them via Hyprland's own env. |
| background is the installed wallpaper, not `screenshot` | screencopy cannot complete against an output DPMS tore down, so the lock surface never finished and never became the keyboard focus. `immediate_render` backs it up. |
| deleted `general:grace` + `general:disable_loading_bar` | **Both were removed in hyprlock 0.9.x.** They logged `config option does not exist` on every single lock, and `grace = 3` silently did nothing. Grace is a CLI flag now, moved to the unit's `ExecStart`. |
| one lock path via `hyprlock.service` | Retires `pidof hyprlock \|\| hyprlock`, which **skipped locking entirely** whenever a previous hyprlock lingered — three times in one day (01:11, 10:13, 14:47: `Executing` with no `Hyprlock version` after). The machine silently failed to lock. Also gives the locker its own cgroup. |
| shutdown backstop | `DefaultTimeoutStopSec=10s` on both managers, `TimeoutStopSec` on the session daemons and locker, and `libvirt-guests` bounded — it ships `TimeoutStopSec=0` (infinity) with `ON_SHUTDOWN=suspend` + `SHUTDOWN_TIMEOUT=300` per guest, free today only because no domains exist. Guarded on `virtualisation.libvirtd.enable` so a fresh clone gets no stub unit. |
| `fprintAuth` off for hyprlock | `pam_fprintd` landed first and `sufficient` with no fingers enrolled, so every lock D-Bus-activated fprintd and sat ~30s for nothing. hyprlock's own `auth:fingerprint:enabled` defaults off, so the reader never drove the UI. Re-enable both together or not at all. |

### Not fully closed

`TimeoutStopSec` on the plugin units is a **partial** mitigation, commented as
such in-tree. Tier-1 plugins require `NotifyAccess=all` (a documented landmine —
bwrap forks the process that reports ready), and such a unit can
`EXTEND_TIMEOUT_USEC` past `TimeoutStopSec` indefinitely with no systemd-side
cap. Latent while `declaredPlugins` is empty. The gap is unchanged; the ordinary
hung-stop case is now bounded.

## Riding along

In the same files, documented rather than split out: Steam desktop actions
(Library / Big Picture / Friends), `PrefersNonDefaultGPU`, `StartupWMClass`,
the `steamlink` scheme handler; `ProtectHome` dropped from the Steam slice
because the library lives in `$HOME`; gamescope + mangohud, remotePlay and
localNetworkGameTransfers firewall, extest, protontricks, desktop-UI scaling;
Hyprland Steam window rules (workspace 9 no longer `silent`, no blanket
fullscreen for `steam_app_*`); and dcf-identity's `secretsFile` moved off a repo
path to `/run/secrets` so it stops being copied into the Nix store.

## Testing

**Verified by parse only** — `nix-instantiate --parse` on every Nix file and
`bash -n` on both scripts. **Not yet evaluated, built, or run on hardware.**

To verify properly:

```bash
sudo nixos-rebuild switch --flake .#nixos --impure   # --impure is mandatory
journalctl --user -u hyprlock -n 30                  # expect NO "Config error"
systemctl --user show-environment | grep DRI_PRIME   # still set for games
systemctl --user start hyprlock.service
hyprctl dispatch dpms off && sleep 5 && hyprctl dispatch dpms on
# password field must accept keys; repeat across a real suspend
journalctl -b -1 | grep -E "powering down|System Power Off"   # after a reboot
```

One caveat for reviewers: `~/.config/hypr/hyprlock.conf` is symlinked by
`home/scripts/theme-switch.sh` into `~/.config/oligarchy/themes/<id>/`, so check
the **theme** copy — both come from the same `renderConf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)